### PR TITLE
Add Evolve page

### DIFF
--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -642,9 +642,35 @@
 					</div>
 				</a>
 			</div>
-		{/if}
+                {/if}
 
-		<div class="relative flex flex-col flex-1 overflow-y-auto overflow-x-hidden">
+                <div class="px-1.5 flex justify-center text-gray-800 dark:text-gray-200">
+                        <a
+                                class="grow flex items-center space-x-3 rounded-lg px-2 py-[7px] hover:bg-gray-100 dark:hover:bg-gray-900 transition"
+                                href="/evolve"
+                                on:click={() => {
+                                        selectedChatId = null;
+                                        chatId.set('');
+
+                                        if ($mobile) {
+                                                showSidebar.set(false);
+                                        }
+                                }}
+                                draggable="false"
+                        >
+                                <div class="self-center">
+                                        <svg class="size-4" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+                                                <path stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m6-6H6" />
+                                        </svg>
+                                </div>
+
+                                <div class="flex self-center translate-y-[0.5px]">
+                                        <div class=" self-center font-medium text-sm font-primary">Evolve</div>
+                                </div>
+                        </a>
+                </div>
+
+                <div class="relative flex flex-col flex-1 overflow-y-auto overflow-x-hidden">
 			{#if ($models ?? []).length > 0 && ($settings?.pinnedModels ?? []).length > 0}
 				<div class="mt-0.5">
 					{#each $settings.pinnedModels as modelId (modelId)}

--- a/src/lib/i18n/locales/de-DE/translation.json
+++ b/src/lib/i18n/locales/de-DE/translation.json
@@ -1419,4 +1419,5 @@
 	"Youtube": "YouTube",
 	"Youtube Language": "YouTube Sprache",
 	"Youtube Proxy URL": "YouTube Proxy URL"
+        "Evolve": "Evolve"
 }

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -1419,4 +1419,5 @@
 	"Youtube": "",
 	"Youtube Language": "",
 	"Youtube Proxy URL": ""
+        "Evolve": ""
 }

--- a/src/routes/(app)/evolve/+layout.svelte
+++ b/src/routes/(app)/evolve/+layout.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { getContext } from 'svelte';
+  import { WEBUI_NAME, showSidebar } from '$lib/stores';
+  import MenuLines from '$lib/components/icons/MenuLines.svelte';
+
+  const i18n = getContext('i18n');
+</script>
+
+<svelte:head>
+  <title>{$i18n.t('Evolve')} • {$WEBUI_NAME}</title>
+</svelte:head>
+
+<div class="flex flex-col w-full h-screen max-h-[100dvh] transition-width duration-200 ease-in-out {$showSidebar ? 'md:max-w-[calc(100%-260px)]' : ''} max-w-full">
+  <nav class="px-2.5 pt-1 backdrop-blur-xl w-full drag-region">
+    <div class="flex items-center">
+      <div class="{$showSidebar ? 'md:hidden' : ''} flex flex-none items-center self-end">
+        <button
+          id="sidebar-toggle-button"
+          class="cursor-pointer p-1.5 flex rounded-xl hover:bg-gray-100 dark:hover:bg-gray-850 transition"
+          on:click={() => showSidebar.set(!$showSidebar)}
+          aria-label="Toggle Sidebar"
+        >
+          <div class="m-auto self-center">
+            <MenuLines />
+          </div>
+        </button>
+      </div>
+      <div class="flex w-full">
+        <div class="text-center text-sm font-medium rounded-full bg-transparent py-1">{$i18n.t('Evolve')}</div>
+      </div>
+    </div>
+  </nav>
+  <div class="flex-1 max-h-full overflow-y-auto">
+    <slot />
+  </div>
+</div>

--- a/src/routes/(app)/evolve/+page.svelte
+++ b/src/routes/(app)/evolve/+page.svelte
@@ -1,0 +1,1 @@
+<h1>Hallo Welt</h1>


### PR DESCRIPTION
## Summary
- add a new `/evolve` route that shows "Hallo Welt"
- add an Evolve entry in the sidebar menu
- create layout for the Evolve page
- localize the Evolve label in English and German

## Testing
- `npm run lint` *(fails: ESLint config & pylint missing)*
- `npm run test:frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867a49283b483309de200d4432dcdcc