### PR TITLE
Add Evolve subpages with Bootstrap tabs

### DIFF
--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -1418,6 +1418,6 @@
 	"Your entire contribution will go directly to the plugin developer; Open WebUI does not take any percentage. However, the chosen funding platform might have its own fees.": "",
 	"Youtube": "",
 	"Youtube Language": "",
-	"Youtube Proxy URL": "",
-        "Evolve": ""
+        "Youtube Proxy URL": "",
+        "Evolve": "Evolve"
 }

--- a/src/routes/(app)/evolve/+page.svelte
+++ b/src/routes/(app)/evolve/+page.svelte
@@ -1,1 +1,24 @@
-<h1>Hallo Welt</h1>
+<script lang="ts">
+  let active = 'tab1';
+</script>
+
+<div class="container mx-auto px-3 py-4">
+  <ul class="nav nav-tabs mb-4">
+    <li class="nav-item">
+      <a href="#" class="nav-link {active === 'tab1' ? 'active' : ''}" on:click|preventDefault={() => active='tab1'}>Tab 1</a>
+    </li>
+    <li class="nav-item">
+      <a href="#" class="nav-link {active === 'tab2' ? 'active' : ''}" on:click|preventDefault={() => active='tab2'}>Tab 2</a>
+    </li>
+    <li class="nav-item">
+      <a href="#" class="nav-link {active === 'tab3' ? 'active' : ''}" on:click|preventDefault={() => active='tab3'}>Tab 3</a>
+    </li>
+  </ul>
+  {#if active === 'tab1'}
+    <iframe src="/evolve/tab1.html" class="w-100 border-0" style="height:80vh"></iframe>
+  {:else if active === 'tab2'}
+    <iframe src="/evolve/tab2.html" class="w-100 border-0" style="height:80vh"></iframe>
+  {:else}
+    <iframe src="/evolve/tab3.html" class="w-100 border-0" style="height:80vh"></iframe>
+  {/if}
+</div>

--- a/src/routes/(app)/evolve/+page.svelte
+++ b/src/routes/(app)/evolve/+page.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
+  import { user } from '$lib/stores';
   let active = 'tab1';
+  $: username = $user?.name ?? '';
+  $: uid = $user?.id ?? '';
+  $: tab1Src = `/evolve/tab1.html?name=${encodeURIComponent(username)}&id=${encodeURIComponent(uid)}`;
 </script>
 
 <div class="container mx-auto px-3 py-4">
@@ -15,7 +19,7 @@
     </li>
   </ul>
   {#if active === 'tab1'}
-    <iframe src="/evolve/tab1.html" class="w-100 border-0" style="height:80vh"></iframe>
+    <iframe src={tab1Src} class="w-100 border-0" style="height:80vh"></iframe>
   {:else if active === 'tab2'}
     <iframe src="/evolve/tab2.html" class="w-100 border-0" style="height:80vh"></iframe>
   {:else}

--- a/static/evolve/tab1.html
+++ b/static/evolve/tab1.html
@@ -11,6 +11,7 @@
 </head>
 <body class="p-3">
     <h2><i class="fa fa-table"></i> Tab 1 Tabelle</h2>
+    <p id="userinfo" class="mt-2"></p>
     <table class="table table-bordered mt-3">
         <thead>
             <tr><th>#</th><th>Name</th><th>Wert</th></tr>
@@ -21,7 +22,15 @@
         </tbody>
     </table>
     <script>
-        $(function(){ console.log('Tab 1 ready'); });
+        $(function(){
+            const params = new URLSearchParams(window.location.search);
+            const name = params.get('name');
+            const id = params.get('id');
+            if (name || id) {
+                $('#userinfo').text('Benutzer: ' + (name || '-') + (id ? ' (' + id + ')' : ''));
+            }
+            console.log('Tab 1 ready');
+        });
     </script>
 </body>
 </html>

--- a/static/evolve/tab1.html
+++ b/static/evolve/tab1.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tab 1</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</head>
+<body class="p-3">
+    <h2><i class="fa fa-table"></i> Tab 1 Tabelle</h2>
+    <table class="table table-bordered mt-3">
+        <thead>
+            <tr><th>#</th><th>Name</th><th>Wert</th></tr>
+        </thead>
+        <tbody>
+            <tr><td>1</td><td>A</td><td>Alpha</td></tr>
+            <tr><td>2</td><td>B</td><td>Beta</td></tr>
+        </tbody>
+    </table>
+    <script>
+        $(function(){ console.log('Tab 1 ready'); });
+    </script>
+</body>
+</html>

--- a/static/evolve/tab2.html
+++ b/static/evolve/tab2.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tab 2</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</head>
+<body class="p-3">
+    <h2><i class="fa fa-chart-column"></i> Tab 2 Tabelle</h2>
+    <table class="table table-striped mt-3">
+        <thead>
+            <tr><th>#</th><th>Produkt</th><th>Preis</th></tr>
+        </thead>
+        <tbody>
+            <tr><td>1</td><td>Produkt A</td><td>10€</td></tr>
+            <tr><td>2</td><td>Produkt B</td><td>20€</td></tr>
+        </tbody>
+    </table>
+    <script>
+        $(function(){ console.log('Tab 2 ready'); });
+    </script>
+</body>
+</html>

--- a/static/evolve/tab3.html
+++ b/static/evolve/tab3.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tab 3</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</head>
+<body class="p-3">
+    <h2><i class="fa fa-user"></i> Tab 3 Tabelle</h2>
+    <table class="table table-hover mt-3">
+        <thead>
+            <tr><th>#</th><th>Name</th><th>Status</th></tr>
+        </thead>
+        <tbody>
+            <tr><td>1</td><td>Max</td><td>Aktiv</td></tr>
+            <tr><td>2</td><td>Lisa</td><td>Inaktiv</td></tr>
+        </tbody>
+    </table>
+    <script>
+        $(function(){ console.log('Tab 3 ready'); });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add translation for Evolve in English locale
- implement 3-tab layout on Evolve page
- provide static HTML pages for each tab using Bootstrap, jQuery and FontAwesome

## Testing
- `npm run test:frontend` *(fails: vitest not found)*
- `pytest -q` *(fails: ModuleNotFoundError and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6867bc313b848330912e373ce972b761