### PR TITLE
Add top navigation tabs for Evolve page

### DIFF
--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -65,6 +65,7 @@ export const banners: Writable<Banner[]> = writable([]);
 export const settings: Writable<Settings> = writable({});
 
 export const showSidebar = writable(false);
+export const evolveActiveTab = writable('tab1');
 export const showSearch = writable(false);
 export const showSettings = writable(false);
 export const showArchivedChats = writable(false);

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -65,7 +65,6 @@ export const banners: Writable<Banner[]> = writable([]);
 export const settings: Writable<Settings> = writable({});
 
 export const showSidebar = writable(false);
-export const evolveActiveTab = writable('tab1');
 export const showSearch = writable(false);
 export const showSettings = writable(false);
 export const showArchivedChats = writable(false);

--- a/src/routes/(app)/evolve/+layout.svelte
+++ b/src/routes/(app)/evolve/+layout.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { getContext } from 'svelte';
-  import { WEBUI_NAME, showSidebar } from '$lib/stores';
-  let activeTab = 'tab1';
+  import { WEBUI_NAME, showSidebar, evolveActiveTab } from '$lib/stores';
   import MenuLines from '$lib/components/icons/MenuLines.svelte';
 
   const i18n = getContext('i18n');
@@ -30,20 +29,20 @@
         <div class="flex gap-1 scrollbar-none overflow-x-auto w-fit text-center text-sm font-medium rounded-full bg-transparent pt-1">
           <a
             href="#"
-            on:click|preventDefault={() => (activeTab = 'tab1')}
-            class="min-w-fit rounded-full p-1.5 {activeTab === 'tab1' ? '' : 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+            on:click|preventDefault={() => evolveActiveTab.set('tab1')}
+            class="min-w-fit rounded-full p-1.5 {$evolveActiveTab === 'tab1' ? '' : 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
             >{$i18n.t('Evolve')}</a
           >
           <a
             href="#"
-            on:click|preventDefault={() => (activeTab = 'tab2')}
-            class="min-w-fit rounded-full p-1.5 {activeTab === 'tab2' ? '' : 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+            on:click|preventDefault={() => evolveActiveTab.set('tab2')}
+            class="min-w-fit rounded-full p-1.5 {$evolveActiveTab === 'tab2' ? '' : 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
             >Tab 2</a
           >
           <a
             href="#"
-            on:click|preventDefault={() => (activeTab = 'tab3')}
-            class="min-w-fit rounded-full p-1.5 {activeTab === 'tab3' ? '' : 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+            on:click|preventDefault={() => evolveActiveTab.set('tab3')}
+            class="min-w-fit rounded-full p-1.5 {$evolveActiveTab === 'tab3' ? '' : 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
             >Tab 3</a
           >
         </div>
@@ -51,6 +50,6 @@
     </div>
   </nav>
   <div class="flex-1 max-h-full overflow-y-auto">
-    <slot {activeTab} />
+    <slot />
   </div>
 </div>

--- a/src/routes/(app)/evolve/+layout.svelte
+++ b/src/routes/(app)/evolve/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { getContext } from 'svelte';
   import { WEBUI_NAME, showSidebar } from '$lib/stores';
+  let activeTab = 'tab1';
   import MenuLines from '$lib/components/icons/MenuLines.svelte';
 
   const i18n = getContext('i18n');
@@ -26,11 +27,30 @@
         </button>
       </div>
       <div class="flex w-full">
-        <div class="text-center text-sm font-medium rounded-full bg-transparent py-1">{$i18n.t('Evolve')}</div>
+        <div class="flex gap-1 scrollbar-none overflow-x-auto w-fit text-center text-sm font-medium rounded-full bg-transparent pt-1">
+          <a
+            href="#"
+            on:click|preventDefault={() => (activeTab = 'tab1')}
+            class="min-w-fit rounded-full p-1.5 {activeTab === 'tab1' ? '' : 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+            >{$i18n.t('Evolve')}</a
+          >
+          <a
+            href="#"
+            on:click|preventDefault={() => (activeTab = 'tab2')}
+            class="min-w-fit rounded-full p-1.5 {activeTab === 'tab2' ? '' : 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+            >Tab 2</a
+          >
+          <a
+            href="#"
+            on:click|preventDefault={() => (activeTab = 'tab3')}
+            class="min-w-fit rounded-full p-1.5 {activeTab === 'tab3' ? '' : 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+            >Tab 3</a
+          >
+        </div>
       </div>
     </div>
   </nav>
   <div class="flex-1 max-h-full overflow-y-auto">
-    <slot />
+    <slot {activeTab} />
   </div>
 </div>

--- a/src/routes/(app)/evolve/+layout.svelte
+++ b/src/routes/(app)/evolve/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { getContext } from 'svelte';
-  import { WEBUI_NAME, showSidebar, evolveActiveTab } from '$lib/stores';
+  import { WEBUI_NAME, showSidebar } from '$lib/stores';
+  import { page } from '$app/stores';
   import MenuLines from '$lib/components/icons/MenuLines.svelte';
 
   const i18n = getContext('i18n');
@@ -28,21 +29,18 @@
       <div class="flex w-full">
         <div class="flex gap-1 scrollbar-none overflow-x-auto w-fit text-center text-sm font-medium rounded-full bg-transparent pt-1">
           <a
-            href="#"
-            on:click|preventDefault={() => evolveActiveTab.set('tab1')}
-            class="min-w-fit rounded-full p-1.5 {$evolveActiveTab === 'tab1' ? '' : 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+            href="/evolve"
+            class="min-w-fit rounded-full p-1.5 {$page.url.pathname === '/evolve' ? '' : 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
             >{$i18n.t('Evolve')}</a
           >
           <a
-            href="#"
-            on:click|preventDefault={() => evolveActiveTab.set('tab2')}
-            class="min-w-fit rounded-full p-1.5 {$evolveActiveTab === 'tab2' ? '' : 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+            href="/evolve/tab2"
+            class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes('/evolve/tab2') ? '' : 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
             >Tab 2</a
           >
           <a
-            href="#"
-            on:click|preventDefault={() => evolveActiveTab.set('tab3')}
-            class="min-w-fit rounded-full p-1.5 {$evolveActiveTab === 'tab3' ? '' : 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+            href="/evolve/tab3"
+            class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes('/evolve/tab3') ? '' : 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
             >Tab 3</a
           >
         </div>

--- a/src/routes/(app)/evolve/+page.svelte
+++ b/src/routes/(app)/evolve/+page.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
-  import { user } from '$lib/stores';
-  export let activeTab: string;
+  import { user, evolveActiveTab } from '$lib/stores';
   $: username = $user?.name ?? '';
   $: uid = $user?.id ?? '';
   $: tab1Src = `/evolve/tab1.html?name=${encodeURIComponent(username)}&id=${encodeURIComponent(uid)}`;
 </script>
 
 <div class="container mx-auto px-3 py-4">
-  {#if activeTab === 'tab1'}
+  {#if $evolveActiveTab === 'tab1'}
     <iframe src={tab1Src} class="w-100 border-0" style="height:80vh"></iframe>
-  {:else if activeTab === 'tab2'}
+  {:else if $evolveActiveTab === 'tab2'}
     <iframe src="/evolve/tab2.html" class="w-100 border-0" style="height:80vh"></iframe>
   {:else}
     <iframe src="/evolve/tab3.html" class="w-100 border-0" style="height:80vh"></iframe>

--- a/src/routes/(app)/evolve/+page.svelte
+++ b/src/routes/(app)/evolve/+page.svelte
@@ -1,26 +1,15 @@
 <script lang="ts">
   import { user } from '$lib/stores';
-  let active = 'tab1';
+  export let activeTab: string;
   $: username = $user?.name ?? '';
   $: uid = $user?.id ?? '';
   $: tab1Src = `/evolve/tab1.html?name=${encodeURIComponent(username)}&id=${encodeURIComponent(uid)}`;
 </script>
 
 <div class="container mx-auto px-3 py-4">
-  <ul class="nav nav-tabs mb-4">
-    <li class="nav-item">
-      <a href="#" class="nav-link {active === 'tab1' ? 'active' : ''}" on:click|preventDefault={() => active='tab1'}>Tab 1</a>
-    </li>
-    <li class="nav-item">
-      <a href="#" class="nav-link {active === 'tab2' ? 'active' : ''}" on:click|preventDefault={() => active='tab2'}>Tab 2</a>
-    </li>
-    <li class="nav-item">
-      <a href="#" class="nav-link {active === 'tab3' ? 'active' : ''}" on:click|preventDefault={() => active='tab3'}>Tab 3</a>
-    </li>
-  </ul>
-  {#if active === 'tab1'}
+  {#if activeTab === 'tab1'}
     <iframe src={tab1Src} class="w-100 border-0" style="height:80vh"></iframe>
-  {:else if active === 'tab2'}
+  {:else if activeTab === 'tab2'}
     <iframe src="/evolve/tab2.html" class="w-100 border-0" style="height:80vh"></iframe>
   {:else}
     <iframe src="/evolve/tab3.html" class="w-100 border-0" style="height:80vh"></iframe>

--- a/src/routes/(app)/evolve/+page.svelte
+++ b/src/routes/(app)/evolve/+page.svelte
@@ -1,16 +1,10 @@
 <script lang="ts">
-  import { user, evolveActiveTab } from '$lib/stores';
+  import { user } from '$lib/stores';
   $: username = $user?.name ?? '';
   $: uid = $user?.id ?? '';
   $: tab1Src = `/evolve/tab1.html?name=${encodeURIComponent(username)}&id=${encodeURIComponent(uid)}`;
 </script>
 
 <div class="container mx-auto px-3 py-4">
-  {#if $evolveActiveTab === 'tab1'}
-    <iframe src={tab1Src} class="w-100 border-0" style="height:80vh"></iframe>
-  {:else if $evolveActiveTab === 'tab2'}
-    <iframe src="/evolve/tab2.html" class="w-100 border-0" style="height:80vh"></iframe>
-  {:else}
-    <iframe src="/evolve/tab3.html" class="w-100 border-0" style="height:80vh"></iframe>
-  {/if}
+  <iframe src={tab1Src} class="w-100 border-0" style="height:80vh"></iframe>
 </div>

--- a/src/routes/(app)/evolve/tab2/+page.svelte
+++ b/src/routes/(app)/evolve/tab2/+page.svelte
@@ -1,0 +1,3 @@
+<div class="container mx-auto px-3 py-4">
+  <iframe src="/evolve/tab2.html" class="w-100 border-0" style="height:80vh"></iframe>
+</div>

--- a/src/routes/(app)/evolve/tab3/+page.svelte
+++ b/src/routes/(app)/evolve/tab3/+page.svelte
@@ -1,0 +1,3 @@
+<div class="container mx-auto px-3 py-4">
+  <iframe src="/evolve/tab3.html" class="w-100 border-0" style="height:80vh"></iframe>
+</div>


### PR DESCRIPTION
## Summary
- add tab navigation to the Evolve layout similar to the workspace page
- show Evolve, Tab 2 and Tab 3 at the top of the screen
- update the page component to use the selected tab from the layout

## Testing
- `npm run test:frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867c39712e4833092190a57862fc925