### PR TITLE
Add system prompt control in tab2

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -422,15 +422,20 @@
 			}
 		}
 
-		if (event.data.type === 'input:prompt:submit') {
-			console.debug(event.data.text);
+                if (event.data.type === 'input:prompt:submit') {
+                        console.debug(event.data.text);
 
-			if (event.data.text !== '') {
-				await tick();
-				submitPrompt(event.data.text);
-			}
-		}
-	};
+                        if (event.data.text !== '') {
+                                await tick();
+                                submitPrompt(event.data.text);
+                        }
+                }
+
+                if (event.data.type === 'systemprompt:set') {
+                        console.debug(event.data.text);
+                        settings.set({ ...$settings, system: event.data.text });
+                }
+        };
 
 	let pageSubscribe = null;
 	onMount(async () => {

--- a/static/evolve/tab2.html
+++ b/static/evolve/tab2.html
@@ -20,8 +20,19 @@
             <tr><td>2</td><td>Produkt B</td><td>20€</td></tr>
         </tbody>
     </table>
+    <div class="mt-4">
+        <input id="system-prompt-input" type="text" class="form-control" placeholder="System Prompt" />
+        <button id="set-system-prompt" class="btn btn-primary mt-2">Systemprompt setzen</button>
+    </div>
     <script>
-        $(function(){ console.log('Tab 2 ready'); });
+        $(function(){
+            console.log('Tab 2 ready');
+
+            $('#set-system-prompt').on('click', function(){
+                const text = $('#system-prompt-input').val();
+                window.parent.postMessage({ type: 'systemprompt:set', text }, window.origin);
+            });
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add input and button to `tab2.html` to send system prompt updates
- handle `systemprompt:set` message in chat to update settings

## Testing
- `npm run lint:frontend` *(fails: ESLint couldn't find config)*
- `npm run test:frontend` *(fails: vitest not found)*
- `npm install` *(fails: ENETUNREACH on github.com)*

------
https://chatgpt.com/codex/tasks/task_e_6867d0239b90833091ccbbb1838d6fb5